### PR TITLE
Update installer URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This script installs [Recyclarr](https://recyclarr.dev/), pulls your custom `rec
 Run this command on your Linux server:
 
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/RetroTrigger/Recyclarr-Installer/refs/heads/main/install-recyclarr.sh)
+bash <(curl -s https://raw.githubusercontent.com/RetroTrigger/Recyclarr-Installer/main/install-recyclarr.sh)
 ```
 ### Features
 


### PR DESCRIPTION
## Summary
- correct README link to use main branch

## Testing
- `bash -n install-recyclarr.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849144b04a8832aa84da4e3b3e314d1