### PR TITLE
Enable distro-agnostic dependency install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bash <(curl -s https://raw.githubusercontent.com/RetroTrigger/Recyclarr-Installe
 
 ## 📋 Requirements
 
-- Linux (Debian/Ubuntu or compatible)
+- Linux with a supported package manager (`apt`, `dnf`, `yum`, `pacman`, `zypper`, or `apk`)
 - Internet access (to download Recyclarr and config)
 
 ## 🔥 After Install

--- a/install-recyclarr.sh
+++ b/install-recyclarr.sh
@@ -33,8 +33,22 @@ info "Starting Recyclarr deluxe installer..."
 
 # --- Install Dependencies ---
 info "Installing required system packages..."
-sudo apt-get update
-sudo apt-get install -y curl unzip wget cron || error "Failed to install dependencies."
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y curl unzip wget cron || error "Failed to install dependencies."
+elif command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y curl unzip wget cronie || error "Failed to install dependencies."
+elif command -v yum >/dev/null 2>&1; then
+  sudo yum install -y curl unzip wget cronie || error "Failed to install dependencies."
+elif command -v pacman >/dev/null 2>&1; then
+  sudo pacman -Sy --noconfirm curl unzip wget cronie || error "Failed to install dependencies."
+elif command -v zypper >/dev/null 2>&1; then
+  sudo zypper install -y curl unzip wget cron || error "Failed to install dependencies."
+elif command -v apk >/dev/null 2>&1; then
+  sudo apk add --no-cache curl unzip wget cron || error "Failed to install dependencies."
+else
+  error "No compatible package manager found. Please install curl, unzip, wget, and cron manually."
+fi
 
 # --- Install Recyclarr ---
 if [ ! -f "$RECYCLARR_BIN" ]; then


### PR DESCRIPTION
## Summary
- support multiple package managers in installer
- update README with broader Linux requirements

## Testing
- `bash -n install-recyclarr.sh`
- `shellcheck install-recyclarr.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684916fef8b0832a95c2b3662bbed96d